### PR TITLE
Update initiatives and admin views

### DIFF
--- a/app/helpers/decidim/admin/filterable_helper.rb
+++ b/app/helpers/decidim/admin/filterable_helper.rb
@@ -14,6 +14,8 @@ module Decidim
         filters_with_values.each_with_object({}) do |(filter, values), hash|
           next if filter == :type_id_eq
 
+          values = reorder_states(values) if filter == :state_eq
+
           link = filter_link_label(filter)
           hash[link] = if values.is_a?(Array)
                          build_submenu_options_tree_from_array(filter, values)
@@ -30,6 +32,7 @@ module Decidim
         links += values.map do |value|
           next if value == "rejected"
           next if value == "accepted"
+
           filter_link_value(filter, value)
         end
         links.each_with_object({}) { |link, hash| hash[link] = nil }
@@ -121,6 +124,22 @@ module Decidim
             t("decidim.admin.actions.cancel"),
             class: "action-icon--remove"
         )
+      end
+
+      private
+
+      def reorder_states(states)
+        ordered_states = []
+
+        ordered_states << "created" if states.member?("created")
+        ordered_states << "validating" if states.member?("validating")
+        ordered_states << "discarded" if states.member?("discarded")
+        ordered_states << "published" if states.member?("published")
+        ordered_states << "classified" if states.member?("classified")
+        ordered_states << "examinated" if states.member?("examinated")
+        ordered_states << "debatted" if states.member?("debatted")
+
+        ordered_states
       end
     end
   end

--- a/app/helpers/decidim/admin/filterable_helper.rb
+++ b/app/helpers/decidim/admin/filterable_helper.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    # Helper that provides methods related to Decidim::Admin::Filterable concern.
+    module FilterableHelper
+      # Renders the filters selector with tags in the admin panel.
+      def admin_filter_selector
+        render partial: "decidim/admin/shared/filters"
+      end
+
+      # Builds a tree of links from Decidim::Admin::Filterable::filters_with_values
+      def submenu_options_tree
+        filters_with_values.each_with_object({}) do |(filter, values), hash|
+          next if filter == :type_id_eq
+
+          link = filter_link_label(filter)
+          hash[link] = if values.is_a?(Array)
+                         build_submenu_options_tree_from_array(filter, values)
+                       elsif values.is_a?(Hash)
+                         build_submenu_options_tree_from_hash(filter, values)
+                       end
+        end
+      end
+
+      # Builds a tree of links from an array. The tree will have only one level.
+      def build_submenu_options_tree_from_array(filter, values)
+        links = []
+        links += extra_dropdown_submenu_options_items(filter)
+        links += values.map do |value|
+          next if value == "rejected"
+          next if value == "accepted"
+          filter_link_value(filter, value)
+        end
+        links.each_with_object({}) { |link, hash| hash[link] = nil }
+      end
+
+      # To be overriden. Useful for adding links that do not match with the filter.
+      # Must return an Array.
+      def extra_dropdown_submenu_options_items(_filter)
+        []
+      end
+
+      # Builds a tree of links from an Hash. The tree can have many levels.
+      def build_submenu_options_tree_from_hash(filter, values)
+        values.each_with_object({}) do |(key, value), hash|
+          link = filter_link_value(filter, key)
+          hash[link] = if value.nil?
+                         nil
+                       elsif value.is_a?(Hash)
+                         build_submenu_options_tree_from_hash(filter, value)
+                       end
+        end
+      end
+
+      # Produces the html for the dropdown submenu from the options tree.
+      # Returns a ActiveSupport::SafeBuffer.
+      def dropdown_submenu(options)
+        content_tag(:ul, class: "vertical menu") do
+          options.map do |key, value|
+            if value.nil?
+              content_tag(:li, key)
+            elsif value.is_a?(Hash)
+              content_tag(:li, class: "is-dropdown-submenu-parent") do
+                key + dropdown_submenu(value)
+              end
+            end
+          end.join.html_safe
+        end
+      end
+
+      def filter_link_label(filter)
+        link_to(i18n_filter_label(filter), href: "#")
+      end
+
+      def filter_link_value(filter, value)
+        link_to(i18n_filter_value(filter, value), query_params_with(filter => value))
+      end
+
+      def i18n_filter_label(filter)
+        t("decidim.admin.filters.#{filter}.label")
+      end
+
+      def i18n_filter_value(filter, value)
+        if I18n.exists?("decidim.admin.filters.#{filter}.values.#{value}")
+          t(value, scope: "decidim.admin.filters.#{filter}.values")
+        else
+          find_dynamic_translation(filter, value)
+        end
+      end
+
+      def applied_filters_hidden_field_tags
+        html = []
+        html += ransack_params.slice(*filters, *extra_filters).map do |filter, value|
+          hidden_field_tag("q[#{filter}]", value)
+        end
+        html += query_params.slice(*extra_allowed_params).map do |filter, value|
+          hidden_field_tag(filter, value)
+        end
+        html.join.html_safe
+      end
+
+      def applied_filters_tags
+        ransack_params.slice(*filters).map do |filter, value|
+          applied_filter_tag(filter, value)
+        end.join.html_safe
+      end
+
+      def applied_filter_tag(filter, value)
+        content_tag(:span, class: "label secondary") do
+          concat "#{i18n_filter_label(filter)}: "
+          concat i18n_filter_value(filter, value)
+          concat remove_filter_icon_link(filter)
+        end
+      end
+
+      def remove_filter_icon_link(filter)
+        icon_link_to(
+            "circle-x",
+            url_for(query_params_without(filter)),
+            t("decidim.admin.actions.cancel"),
+            class: "action-icon--remove"
+        )
+      end
+    end
+  end
+end

--- a/app/views/decidim/admin/dashboard/show.html.erb
+++ b/app/views/decidim/admin/dashboard/show.html.erb
@@ -1,0 +1,31 @@
+
+<h2 class="card-title">
+  <%= t "decidim.admin.titles.dashboard" %>
+</h2>
+
+<div class="content">
+  <p><%= t ".welcome" %></p>
+
+  <%# unless current_user.admin_terms_accepted? %>
+    <%# cell("decidim/announcement", admin_terms_announcement_args ) %>
+  <%# end %>
+
+  <% if allowed_to? :read, :admin_log %>
+    <div class="row">
+      <h3 class="card-title">
+      </h3>
+      <%= render partial: "decidim/admin/logs/logs_list", locals: { logs: latest_action_logs } %>
+      <% if latest_action_logs.any? %>
+        <div class="text-center"><%= link_to t(".view_more_logs"), logs_path %></div>
+      <% end %>
+    </div>
+  <% end %>
+
+  <% if current_user.admin_terms_accepted? %>
+    <p class="text-right">
+      <small>
+        <%= link_to( t("title", scope: "decidim.admin.admin_terms_of_use"), admin_terms_show_path) %>
+      </small>
+    </p>
+  <% end %>
+</div>

--- a/app/views/layouts/decidim/admin/initiative.html.erb
+++ b/app/views/layouts/decidim/admin/initiative.html.erb
@@ -1,0 +1,30 @@
+<% content_for :secondary_nav do %>
+  <div class="secondary-nav secondary-nav--subnav">
+    <ul>
+      <%= public_page_link decidim_initiatives.initiative_path(current_participatory_space) %>
+      <% if allowed_to? :edit, :initiative, initiative: current_participatory_space %>
+        <li <% if is_active_link?(decidim_admin_initiatives.edit_initiative_path(current_participatory_space)) %> class="is-active" <% end %>>
+          <%= aria_selected_link_to t(".information"), decidim_admin_initiatives.edit_initiative_path(current_participatory_space) %>
+        </li>
+      <% end %>
+
+      <% if current_participatory_space.promoting_committee_enabled? && allowed_to?(:manage_membership, :initiative, initiative: current_participatory_space) %>
+        <li <% if is_active_link?(decidim_admin_initiatives.initiative_committee_requests_path(current_participatory_space)) %> class="is-active" <% end %>>
+          <%= aria_selected_link_to t(".committee_members"), decidim_admin_initiatives.initiative_committee_requests_path(current_participatory_space) %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<%= render "layouts/decidim/admin/application" do %>
+  <div class="process-title">
+    <div class="process-title-content">
+      <%= link_to translated_attribute(current_participatory_space.title), decidim_initiatives.initiative_path(current_participatory_space), target: "_blank" %>
+    </div>
+  </div>
+
+  <div class="process-content">
+    <%= yield %>
+  </div>
+<% end %>

--- a/config/initializers/decidim-initiatives.rb
+++ b/config/initializers/decidim-initiatives.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 if defined?(Decidim::Initiatives) && defined?(Decidim::Initiatives.do_not_require_authorization)
-  # Decidim::Initiatives.configure do |config|
+  Decidim::Initiatives.configure do |config|
   #
   #   # Public Setting that defines the similarity minimum value to consider two
   #   # initiatives similar. Defaults to 0.25.
@@ -20,7 +20,7 @@ if defined?(Decidim::Initiatives) && defined?(Decidim::Initiatives.do_not_requir
   #   config.default_signature_time_period_length = 6.months
   #
   #   # Components enabled for a new initiative
-  #   config.default_components = []
+    config.default_components = []
   #
   #   # Print functionality enabled. Allows the user to get
   #   # a printed version of the initiative from the administration
@@ -33,5 +33,5 @@ if defined?(Decidim::Initiatives) && defined?(Decidim::Initiatives.do_not_requir
   #   # timestamped and respond to a timestamp method
   #   config.timestamp_service = "Decidim::Initiatives::UtcTimestamp"
   #
-  # end
+  end
 end


### PR DESCRIPTION
#### What, why ?

- [x] Disable defaults initiatives components
- [x] Hide 'Components', 'Attachments', 'Moderations' in initiative BO
- [x] Hide 'rejected', 'accepted' states in initiatives index sort dropdown
- [x] Hide 'type' sort list in initiatives index
- [x] Sort states in initiatives index sort dropdown
- [x] Hide TOS section in admin dashboard

#### 📷 screenshots

<img width="308" alt="Screenshot_2020-06-16_at_12 07 18" src="https://user-images.githubusercontent.com/26109239/84777670-2ff0c780-afe2-11ea-90cb-4a2dcbcef72f.png">

<img width="481" alt="Capture_decran_2020-06-16_a_11 40 35" src="https://user-images.githubusercontent.com/26109239/84777668-2ebf9a80-afe2-11ea-8cd5-b7ff92e7adca.png">

<img width="1292" alt="Capture_decran_2020-06-16_a_14 24 30" src="https://user-images.githubusercontent.com/26109239/84777665-2cf5d700-afe2-11ea-8a70-d4ca49fd0d08.png">
