### PR TITLE
only display author france connect link for committee request

### DIFF
--- a/app/views/decidim/devise/shared/_omniauth_buttons.html.erb
+++ b/app/views/decidim/devise/shared/_omniauth_buttons.html.erb
@@ -2,6 +2,8 @@
   <div class="row">
     <div class="<%= column_classes %>">
       <%- current_organization.enabled_omniauth_providers.each do |name,provider| %>
+        <% next if name == :france_connect_uid && request.env['PATH_INFO'].include?("/committee_requests/new") %>
+
         <% if request.env.dig(:available_authorizations).nil? || request.env.dig(:available_authorizations).include?(name.to_s) %>
           <% if I18n.exists?("decidim.omniauth.#{name}.explanation") %>
             <div class="callout">


### PR DESCRIPTION
#### What, why ?
When requesting to be part of the promoting committee, the user see the FC modal with the 2 connection buttons : signataire & author. 

#### Expected
Only the author button and text should be displayed only for the committee requests route.