### PR TITLE
Change 'secondary' class to 'success' in finish initiative signature

### DIFF
--- a/app/views/decidim/initiatives/initiative_signatures/finish.html.erb
+++ b/app/views/decidim/initiatives/initiative_signatures/finish.html.erb
@@ -1,0 +1,17 @@
+<div class="callout success mb-sm">
+  <p>
+    <%= t("create.success_html",
+          scope: "decidim.initiatives.initiative_votes",
+          title: translated_attribute(current_initiative.title)) %>
+  </p>
+</div>
+<h2 class="section-heading"><%= t("finished", scope: "layouts.decidim.initiative_signature_creation_header") %></h2>
+
+<%= render partial: "wizard_steps" %>
+
+<div class="card">
+  <br>
+  <div class="column actions">
+    <%= link_to t(".back_to_initiative"), initiative_path(current_initiative), class: "button white-button expanded" %>
+  </div>
+</div>


### PR DESCRIPTION
On last step of the signature process, the layout to announce the success of the signature process is red. It should be green. 