### PR TITLE
Fix missing send validation button

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 
 GIT
   remote: https://github.com/OpenSourcePolitics/decidim.git
-  revision: 7c8af61a2e9c1cedb51dea896700445e3d0f9e6f
+  revision: 5de8a644b09692905eae239af66ee4873d0c7cbf
   branch: alt/petition_merge
   specs:
     decidim (0.22.0.dev)

--- a/app/views/decidim/initiatives/create_initiative/finish.html.erb
+++ b/app/views/decidim/initiatives/create_initiative/finish.html.erb
@@ -21,7 +21,7 @@
       </div>
 
       <div class="column actions">
-        <% unless promotal_committee_required? %>
+        <%  if !promotal_committee_required? || minimum_committee_members == 1 %>
           <%= link_to t(".send_my_initiative"),
                       decidim_admin_initiatives.send_to_technical_validation_initiative_path(current_initiative),
                       class: "button success light expanded",


### PR DESCRIPTION
#### What ? Why ?
As an admin, when configuring Min committee member is equal to 1, I expect the "Send to technical validation" button to appear at step 5 of creation initiative form. 

#### Related to 
- https://github.com/OpenSourcePolitics/decidim/pull/992
- Commit : 
https://github.com/OpenSourcePolitics/decidim/commit/5de8a644b09692905eae239af66ee4873d0c7cbf

#### 📋 Tasks
- [x] Update validation button display condition