### PR TITLE
Update initiative mailer link

### DIFF
--- a/app/views/decidim/initiatives/initiatives_mailer/notify_creation.html.erb
+++ b/app/views/decidim/initiatives/initiatives_mailer/notify_creation.html.erb
@@ -16,5 +16,5 @@
 <p>
   <%= t("check_initiative_details", scope: "decidim.initiatives.initiatives_mailer.initiative_link") %>
   <%= link_to t("here",  scope: "decidim.initiatives.initiatives_mailer.initiative_link"),
-              decidim_admin_initiatives.initiative_url(@initiative, host: @organization.host) %>
+              decidim_initiatives.initiative_url(@initiative, host: @organization.host) %>
 </p>


### PR DESCRIPTION
#### What ? Why ? 
When receiving a notification about an initiative creation, the link displayed in the mail redirects the user on the following page : `*/admin/initiatives/i-XX`

"Vous pouvez accéder aux détails `ici`"
#### Expected behaviour
When clicked, this link must redirect to the initiative show in FO

#### 📋 Subtasks
- [x] Edit link in view