### PR TITLE
Fix omniauth button modals display

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,14 @@
 module ApplicationHelper
+  def allowed_omniauth?(provider_name)
+    return true if request.env['PATH_INFO'].end_with?('/users/sign_in')
+    return true if request.env['PATH_INFO'].end_with?('/committee_requests/new')
+
+    (available_authorizations? && request.env.dig(:available_authorizations).include?(provider_name.to_s))
+  end
+
+  private
+
+  def available_authorizations?
+    !(request.env.dig(:available_authorizations).nil? || request.env.dig(:available_authorizations).empty?)
+  end
 end

--- a/app/views/decidim/devise/shared/_omniauth_buttons.html.erb
+++ b/app/views/decidim/devise/shared/_omniauth_buttons.html.erb
@@ -5,13 +5,7 @@
         <%# Don't display france connect uid when requesting to join a committee %>
         <% next if name == :france_connect_uid && request.env['PATH_INFO'].end_with?("/committee_requests/new") %>
 
-        <%# Don't display france connect uid when creating an initiative %>
-        <% next if name == :france_connect_uid && request.env['PATH_INFO'].end_with?("/initiatives") %>
-
-        <%# Don't display france connect author when signing an initiative %>
-        <% next if name == :france_connect_profile && request.env['PATH_INFO'].include?("/initiatives") && !request.env['PATH_INFO'].end_with?("/initiatives") && !request.env['PATH_INFO'].end_with?("/committee_requests/new") %>
-
-        <% if request.env.dig(:available_authorizations).nil? || request.env.dig(:available_authorizations).include?(name.to_s) %>
+        <% if allowed_omniauth?(name) %>
           <% if I18n.exists?("decidim.omniauth.#{name}.explanation") %>
             <div class="callout">
               <%== t("decidim.omniauth.#{name}.explanation") %>


### PR DESCRIPTION
Refactor omniauth modal buttons logic

#### Describe
Les modales en question affichent désormais un seul bouton, mais il s'agit uniquement du bouton signataire. 

Sur les deux modales suivantes, c'est le bouton auteur qui doit être présent : 

- Invitation co-auteur
- Dépôt d'une pétition