### PR TITLE
Fix author account deletion

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -25,8 +25,12 @@ module ApplicationHelper
   end
 
   def request_available_authorizations
-    return "" if request.env.dig(:available_authorizations).nil? || request.env.dig(:available_authorizations).empty?
+    return '' if request.env.dig(:available_authorizations).nil? || request.env.dig(:available_authorizations).empty?
 
-    "/" + request.env.dig(:available_authorizations).join("-")
+    '/' + request.env.dig(:available_authorizations).join('-')
+  end
+
+  def existing_author?(author_id)
+    Decidim::User.find(author_id).delete_reason.nil?
   end
 end

--- a/app/views/decidim/initiatives/admin/initiatives/edit.html.erb
+++ b/app/views/decidim/initiatives/admin/initiatives/edit.html.erb
@@ -12,7 +12,7 @@
         <%= current_initiative.author.name %>
       </div>
       <div class="author--actions">
-        <% if authorizations.any? && authorizations.first.metadata.present? %>
+        <% if authorizations.any? && authorizations.first.metadata.present? && existing_author?(current_initiative.decidim_author_id) %>
           <%= metadata_modal_button_to authorizations.first, method: :get, remote: true, class: "button tiny hollow" do %>
             <%= icon "shield" %>
             <%= t "actions.metadata", scope: "decidim.verifications.omniauth.admin.authorizations.index" %>


### PR DESCRIPTION
## What? Why?
After the author of an initiative has deleted her account, her personal data are still available in admin panel. (Cf: button "voir le profile") 

This helper ensure to avoid accessing the profile button if user is deleted

Route : `admin/initiatives/i-<ID>/edit`