### PR TITLE
Missing asset on pdf export

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -11,4 +11,4 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
-Rails.application.config.assets.precompile += %w( decidim/admin/initiatives-extras.css )
+Rails.application.config.assets.precompile += %w( decidim/admin/initiatives-extras.css decidim/initiatives/initiatives-votes.css )


### PR DESCRIPTION
## What ? Why?

When admin exports initiative in PDF, an internal error occurs because of missing asset `decidim/initiatives/initiatives-votes.css`. This error only occurs on production mode.

According to [wicked_pdf documentation](https://github.com/mileszs/wicked_pdf#asset-pipeline-usage), add the specific missing asset in `config.precompile`