### PR TITLE
update creation initiative mailer view

### DIFF
--- a/app/views/decidim/initiatives/initiatives_mailer/notify_creation.html.erb
+++ b/app/views/decidim/initiatives/initiatives_mailer/notify_creation.html.erb
@@ -1,16 +1,8 @@
 <p>
 <%= t "decidim.initiatives.initiatives_mailer.creation_subject", title: translated_attribute(@initiative.title) %>.
-<%= link_to t("decidim.initiatives.initiatives_mailer.more_information"), decidim.page_url("initiatives", host: @organization.host) %>
+<%= link_to t("decidim.initiatives.initiatives_mailer.more_information"), decidim.page_url("definition_petition", host: @organization.host) %>
 </p>
 
-<p>
-  <%== t "decidim.initiatives.initiatives_mailer.creation_subject", title: translated_attribute(@initiative.title) %>.
-</p>
-<br/>
-
-<p>
-  <%== t("decidim.initiatives.initiatives_mailer.more_information") %>
-</p>
 <br/>
 
 <p>

--- a/app/views/decidim/initiatives/initiatives_mailer/notify_creation.html.erb
+++ b/app/views/decidim/initiatives/initiatives_mailer/notify_creation.html.erb
@@ -1,6 +1,6 @@
 <p>
 <%= t "decidim.initiatives.initiatives_mailer.creation_subject", title: translated_attribute(@initiative.title) %>.
-<%= link_to t("decidim.initiatives.initiatives_mailer.more_information"), decidim.page_url("definition_petition", host: @organization.host,  rel: "notrack") %>
+<%= link_to t("decidim.initiatives.initiatives_mailer.more_information"), decidim.page_url("definition_petition", host: @organization.host), rel: "notrack" %>
 </p>
 
 <br/>

--- a/app/views/decidim/initiatives/initiatives_mailer/notify_creation.html.erb
+++ b/app/views/decidim/initiatives/initiatives_mailer/notify_creation.html.erb
@@ -1,6 +1,6 @@
 <p>
 <%= t "decidim.initiatives.initiatives_mailer.creation_subject", title: translated_attribute(@initiative.title) %>.
-<%= link_to t("decidim.initiatives.initiatives_mailer.more_information"), decidim.page_url("definition_petition", host: @organization.host) %>
+<%= link_to t("decidim.initiatives.initiatives_mailer.more_information"), decidim.page_url("definition_petition", host: @organization.host,  rel: "notrack") %>
 </p>
 
 <br/>
@@ -8,5 +8,5 @@
 <p>
   <%= t("check_initiative_details", scope: "decidim.initiatives.initiatives_mailer.initiative_link") %>
   <%= link_to t("here",  scope: "decidim.initiatives.initiatives_mailer.initiative_link"),
-              decidim_initiatives.initiative_url(@initiative, host: @organization.host) %>
+              decidim_initiatives.initiative_url(@initiative, host: @organization.host), rel: "notrack" %>
 </p>


### PR DESCRIPTION
- [x] Remove duplicated key in initiative creation mail. 
- [x] Redefine "more information" link from `initiatives pages` to `definition_petition` page
- [x] Add `rel="notrack"` attribute on links to avoid url rewriting in mail links