### PR TITLE
change term_customizer repo for testing cache error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "decidim-initiatives", git: "https://github.com/OpenSourcePolitics/decidim.g
 # gem "decidim-consultations", path: "../decidim"
 # gem "decidim-initiatives", path: "../decidim"
 
-gem "decidim-term_customizer", git: "https://github.com/OpenSourcePolitics/decidim-module-term_customizer.git", branch: "0.dev"
+gem "decidim-term_customizer", git: "https://github.com/Quentinchampenois/decidim-module-term_customizer.git", branch: "fix/rescue_argumenterror"
 
 # gem "omniauth-decidim", git: "https://github.com/OpenSourcePolitics/decidim.git"
 # gem "decidim-omniauth_extras", git: "https://github.com/OpenSourcePolitics/decidim.git"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,4 @@
 GIT
-  remote: https://github.com/OpenSourcePolitics/decidim-module-term_customizer.git
-  revision: e5b83247eb33c8a6d4c1adb48d0ed9764b826530
-  branch: 0.dev
-  specs:
-    decidim-term_customizer (0.dev)
-      decidim-admin
-      decidim-core
-
-GIT
   remote: https://github.com/OpenSourcePolitics/decidim.git
   revision: e1bffd083e625dfe82cec22ade2e4894ec9d0b72
   branch: alt/petition_merge
@@ -216,6 +207,15 @@ GIT
       sassc-rails (~> 2.1.2)
     decidim-verifications (0.22.0.dev)
       decidim-core (= 0.22.0.dev)
+
+GIT
+  remote: https://github.com/Quentinchampenois/decidim-module-term_customizer.git
+  revision: 1d98df0a4e63f4a73d4fa71be4279ed58ac9db47
+  branch: fix/rescue_argumenterror
+  specs:
+    decidim-term_customizer (0.dev)
+      decidim-admin
+      decidim-core
 
 GEM
   remote: https://rubygems.org/


### PR DESCRIPTION
Change term_customizer repository for testing clear cache server error.

This new repo aims to rescue ArgumentError and running a `tmp:cache:clear` command and then clear cache

Cf: https://github.com/Quentinchampenois/decidim-module-term_customizer/commit/1d98df0a4e63f4a73d4fa71be4279ed58ac9db47

