### PR TITLE
Fix allow html for help text

### DIFF
--- a/app/views/decidim/initiatives/create_initiative/promotal_committee.html.erb
+++ b/app/views/decidim/initiatives/create_initiative/promotal_committee.html.erb
@@ -1,0 +1,20 @@
+<% content_for :back_link do %>
+  <%= link_to :back do %>
+    <%= icon "chevron-left", class: "icon--small", aria_label: t(".back"), role: "img" %>
+    <%= t(".back") %>
+  <% end %>
+<% end %>
+
+<div class="row column">
+  <div class="medium-centered">
+    <div class="callout secondary">
+      <%== t ".individual_help_text", committee_size: current_initiative.minimum_committee_members %>
+    </div>
+  </div>
+</div>
+<br>
+<div class="row">
+  <div class="small-12 medium-centered">
+    <%= render partial: "share_committee_link" %>
+  </div>
+</div>


### PR DESCRIPTION
# What ? Why ?

The `decidim.initiatives.create_initiative.promotal_committee.individual_help_text` translation key needs some HTML formatting. 

# Screenshot

<img width="909" alt="Screenshot 2020-09-10 at 14 44 11" src="https://user-images.githubusercontent.com/26109239/92731137-ffb48d00-f374-11ea-9534-f821038f0385.png">

