### PR TITLE
update user name field

### DIFF
--- a/db/migrate/20200910132431_update_auth_user_name.rb
+++ b/db/migrate/20200910132431_update_auth_user_name.rb
@@ -1,0 +1,7 @@
+class UpdateAuthUserName < ActiveRecord::Migration[5.2]
+  def change
+    Decidim::Authorization.where(name: 'france_connect_profile').each do |auth|
+      auth.user.update_columns(name: auth.metadata[:first_name]&.split(' ')&.first)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_02_172116) do
+ActiveRecord::Schema.define(version: 2020_09_10_132431) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"

--- a/lib/omniauth/strategies/france_connect_profile.rb
+++ b/lib/omniauth/strategies/france_connect_profile.rb
@@ -11,7 +11,7 @@ module OmniAuth
 
       info do
         {
-          name: "#{user_info.given_name} #{find_name}".strip,
+          name: "#{user_info.given_name&.split(" ")&.first} #{find_name}".strip,
           email: user_info.email,
           nickname: ::Decidim::UserBaseEntity.nicknamize(find_name),
           first_name: user_info.given_name&.strip,


### PR DESCRIPTION
# What? Why?
On the initiatives index FO, the identities sent show all the user first names and its last name. 

# Expected behaviour 
As a user, I expect only my first 'first name' to be displayed in FO, on the initiative page & on the initiative index. 

As an admin, I expect all the users first names to be displayed on BO

## Screenshot : new version 

Initiative card
<img width="315" alt="Screenshot 2020-09-10 at 17 21 26" src="https://user-images.githubusercontent.com/26109239/92754672-5e850100-f38b-11ea-9195-36a26e3cc1cd.png">

Show initiative
<img width="370" alt="Screenshot 2020-09-10 at 17 22 22" src="https://user-images.githubusercontent.com/26109239/92754721-6b095980-f38b-11ea-9b55-8220a525af65.png">
