### PR TITLE
add current_locale to cache

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,7 +26,7 @@ GIT
 
 GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module_cookies
-  revision: fac0d0d4068a4cf98cd6946560529540b683b0e8
+  revision: c9a095c6cb5f897db63e81a65dea21c52cee05de
   branch: alt/bosa
   specs:
     decidim-cookies (0.22.0.dev)

--- a/app/views/decidim/devise/sessions/new.html.erb
+++ b/app/views/decidim/devise/sessions/new.html.erb
@@ -19,7 +19,7 @@
       <% end %>
     </div>
   </div>
-  <% cache current_organization do %>
+  <% cache [current_organization, current_locale] do %>
     <%= render partial: "decidim/devise/shared/omniauth_buttons", locals: { column_classes: "columns large-4 mediumlarge-6 medium-8 medium-centered" } %>
   <% end %>
   <% if current_organization.sign_up_enabled? || request.env['PATH_INFO'].include?("/admin_sign_in") %>

--- a/app/views/decidim/shared/_login_modal.html.erb
+++ b/app/views/decidim/shared/_login_modal.html.erb
@@ -32,7 +32,7 @@
         </p>
       </div>
     </div>
-    <% cache current_organization do %>
+    <% cache [current_organization, current_locale] do %>
       <%= render "decidim/devise/shared/omniauth_buttons_mini" %>
     <% end %>
   <% elsif current_organization.sign_in_enabled? %>
@@ -45,7 +45,7 @@
         </p>
       </div>
     </div>
-    <% cache current_organization do %>
+    <% cache [current_organization, current_locale] do %>
       <%= render "decidim/devise/shared/omniauth_buttons" %>
     <% end %>
   <% end %>


### PR DESCRIPTION
# What ? Why ?

When a user access to the signin route, the omniauth buttons does not change translation if user change the current locale.

## 📓 Tasks

- [x] Add current locale to cache
- [x] Bump module cookies version