### PR TITLE
Fix translation keys

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,6 +72,11 @@ en:
     system:
       organizations:
         omniauth_settings:
+          decidim:
+            client_id: Client ID
+            client_secret: Client secret
+            provider_name: Provider name
+            site_url: Site url
           saml:
             provider_name: Provider name
             icon_path: Icon path

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,6 +49,8 @@ en:
         name: BOSA dummy authorization
         explanation: Add additional informations to your account
       saml:
+        fields:
+          date_of_birth: Date of birth
         name: CSAM eID
         explanation: Validate with your CSAM eID account
     authorization_modals:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -48,6 +48,8 @@ nl:
       omniauth_anti_affinity:
         explanation: Explanation
       saml:
+        fields:
+          date_of_birth: Date of birth
         explanation: Validate with your CSAM eID account
         name: CSAM eID
       started_at: Started at

--- a/lib/decidim/verifications/omniauth/bosa_action_authorizer.rb
+++ b/lib/decidim/verifications/omniauth/bosa_action_authorizer.rb
@@ -12,7 +12,7 @@ module Decidim
 
           if status_code == :ok && action == "vote" && minimum_age.present? && under_minimum_age?(minimum_age)
             status_code = :unauthorized
-            data[:fields] = { "date_of_birth" => I18n.t("decidim.verifications.omniauth.errors.minimum_age", minimum_age: minimum_age, locale: authorization.user.locale) }
+            data[:fields] = { "date_of_birth" => I18n.t("decidim.verifications.omniauth.errors.minimum_age", minimum_age: minimum_age, locale: current_locale) }
           end
 
           [status_code, data]


### PR DESCRIPTION
## Intro

I could not check the validity of changes because of local environment. Hope translations are OK and `current_locale` used in authorization modal is fonctionnal. 

## 🗒️ Tasks

- [x] Enable language change for authorization modal (cf screen 1)
- [x] Add missing key `nl.decidim.authorization_handlers.saml.fields.date_of_birth` 
- [x] Add translation keys for `/system` route

## 📷 Screenshots

Screen 1
![authorization_handler](https://user-images.githubusercontent.com/26109239/93115621-6363f080-f6bc-11ea-9005-5112eb830854.png)

## Undone

- [ ]  P1 SAML 
I think translations are related to `lib/omniauth/strategies/eid_saml.rb:62` but not sure for now

![account](https://user-images.githubusercontent.com/26109239/93115889-ce152c00-f6bc-11ea-864c-023084ba5a80.png)


