### PR TITLE
Add omniauth registration fields

### DIFF
--- a/app/views/decidim/account/show.html.erb
+++ b/app/views/decidim/account/show.html.erb
@@ -61,7 +61,28 @@
             </div>
           <% end %>
 
-          <%= f.text_area :full_address, rows: 2, maxlength: 256, class: ""  %>
+          <%= f.text_field :full_address, value: current_user.try(:full_address) || "", readonly: true %>
+
+          <div class="field">
+            <%= f.text_field :number_and_street %>
+          </div>
+
+          <div class="field">
+            <%= f.text_field :address_complement %>
+          </div>
+
+          <div class="field">
+            <%= f.text_field :postal_code %>
+          </div>
+
+          <div class="field">
+            <%= f.text_field :city %>
+          </div>
+
+          <div class="field">
+            <%= f.text_field :country %>
+          </div>
+
           <%= f.check_box :custom_agreement, label: t(".custom_agreement") %>
 
           <div class="actions">

--- a/app/views/decidim/devise/omniauth_registrations/new.html.erb
+++ b/app/views/decidim/devise/omniauth_registrations/new.html.erb
@@ -44,7 +44,23 @@
               </div>
 
               <div class="field">
-                <%= f.text_area :full_address, rows: 2, maxlength: 256, class: ""  %>
+                <%= f.text_field :number_and_street %>
+              </div>
+
+              <div class="field">
+                <%= f.text_field :address_complement %>
+              </div>
+
+              <div class="field">
+                <%= f.text_field :postal_code %>
+              </div>
+
+              <div class="field">
+                <%= f.text_field :city %>
+              </div>
+
+              <div class="field">
+                <%= f.text_field :country %>
               </div>
 
               <div class="field custom_agreement">

--- a/app/views/decidim/verifications/metadata/_content.html.erb
+++ b/app/views/decidim/verifications/metadata/_content.html.erb
@@ -10,6 +10,10 @@
   <div class="callout primary">
     <p>
       <%= decidim_sanitize t(".active_email", email: @user.email, full_address: @user.full_address) %>
+
+      <% unless @user.address.blank? %>
+        <%= decidim_sanitize t(".address_complement", address_complement: @user.address["address_complement"]) unless @user.address["address_complement"].blank? %>
+      <% end %>
     </p>
   </div>
 </div>

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -146,6 +146,8 @@ fr:
       metadata:
         content:
           active_email: "<b>Cet utilisateur peut être contacté aux coordonnées suivantes: <p><a href=\"mailto:%{email}\">%{email}</a><br/>%{full_address}</p></b>"
+          address_complement: "Complément d'adresse : %{address_complement}"
+
   devise:
     mailer:
       confirmation_instructions:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -9,7 +9,13 @@ fr:
         title: Titre
         weight: Ordre de présentation
       user:
+        address_complement: Complément d'adresse
+        city: Commune
+        country: Pays
         full_address: Votre adresse postale
+        number_and_street: Numéro et libellé de la voie
+        postal_code: Code postal
+
     models:
       decidim/attachment_created_event: Pièce jointe
   decidim:

--- a/db/migrate/20201022120625_add_address_data_to_decidim_users.rb
+++ b/db/migrate/20201022120625_add_address_data_to_decidim_users.rb
@@ -1,0 +1,5 @@
+class AddAddressDataToDecidimUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_users, :address, :jsonb, default: {}, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_10_132432) do
+ActiveRecord::Schema.define(version: 2020_10_22_120625) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -1558,6 +1558,7 @@ ActiveRecord::Schema.define(version: 2020_09_10_132432) do
     t.string "full_address"
     t.boolean "custom_agreement"
     t.datetime "custom_agreement_at"
+    t.jsonb "address", default: {}, null: false
     t.index ["confirmation_token"], name: "index_decidim_users_on_confirmation_token", unique: true
     t.index ["decidim_organization_id"], name: "index_decidim_users_on_decidim_organization_id"
     t.index ["id", "type"], name: "index_decidim_users_on_id_and_type"

--- a/lib/extends/account_form_extend.rb
+++ b/lib/extends/account_form_extend.rb
@@ -6,18 +6,22 @@ module AccountFormExtend
   extend ActiveSupport::Concern
 
   included do
+    include Decidim::JsonbAttributes
 
     attribute :email_on_notification, Virtus::Attribute::Boolean
     attribute :custom_agreement, Virtus::Attribute::Boolean
-    attribute :full_address, String
+    jsonb_attribute :address, [
+        [:number_and_street, String],
+        [:address_complement, String],
+        [:postal_code, Integer],
+        [:city, String],
+        [:country, String]
+    ]
 
     validates :email, 'valid_email_2/email': { mx: true }
-
     validates :avatar, file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_avatar_size } }
-
     validates :custom_agreement, acceptance: true
-    validates :full_address, presence: true
-    validates_length_of :full_address, maximum: 256, allow_blank: false, unless: -> (form) { form.email.blank? }
+    validates :number_and_street, :postal_code, :city, :country, presence: true
 
     validate :unique_email
   end

--- a/lib/extends/create_omniauth_registration_extend.rb
+++ b/lib/extends/create_omniauth_registration_extend.rb
@@ -73,7 +73,7 @@ module CreateOmniauthRegistrationExtend
           @user.password_confirmation = generated_password
 
           @user.address = form.address
-          @user.full_address = create_full_address
+          @user.full_address = computed_full_address
           @user.custom_agreement_at = DateTime.now if form.custom_agreement
 
           # TODO: raise ActiveRecord::RecordInvalid because of quality setting on uploader, this line is a quick fix
@@ -90,7 +90,7 @@ module CreateOmniauthRegistrationExtend
 
     private
 
-    def create_full_address
+    def computed_full_address
       "#{form.number_and_street}, #{form.city} #{form.postal_code}, #{form.country}"
     end
   end

--- a/lib/extends/create_omniauth_registration_extend.rb
+++ b/lib/extends/create_omniauth_registration_extend.rb
@@ -72,7 +72,8 @@ module CreateOmniauthRegistrationExtend
           @user.password = generated_password
           @user.password_confirmation = generated_password
 
-          @user.full_address = form.full_address
+          @user.address = form.address
+          @user.full_address = create_full_address
           @user.custom_agreement_at = DateTime.now if form.custom_agreement
 
           # TODO: raise ActiveRecord::RecordInvalid because of quality setting on uploader, this line is a quick fix
@@ -87,6 +88,11 @@ module CreateOmniauthRegistrationExtend
       @user.save!
     end
 
+    private
+
+    def create_full_address
+      "#{form.number_and_street}, #{form.city} #{form.postal_code}, #{form.country}"
+    end
   end
 end
 

--- a/lib/extends/omniauth_registration_form_extend.rb
+++ b/lib/extends/omniauth_registration_form_extend.rb
@@ -6,17 +6,24 @@ module OmniauthRegistrationFormExtend
   extend ActiveSupport::Concern
 
   included do
+    include Decidim::JsonbAttributes
 
     def self.extra_params
-      [:custom_agreement, :full_address]
+      [:custom_agreement, :number_and_street,
+       :address_complement,
+       :postal_code,
+       :city,
+       :country]
     end
 
     attribute :custom_agreement, Virtus::Attribute::Boolean
-    attribute :number_and_street, String
-    attribute :address_complement, String
-    attribute :postal_code, String
-    attribute :city, String
-    attribute :country, String
+    jsonb_attribute :address, [
+        [:number_and_street, String],
+        [:address_complement, String],
+        [:postal_code, Integer],
+        [:city, String],
+        [:country, String]
+    ]
 
     validates :email, 'valid_email_2/email': { mx: true }
     validates :name, presence: true

--- a/lib/extends/omniauth_registration_form_extend.rb
+++ b/lib/extends/omniauth_registration_form_extend.rb
@@ -9,11 +9,7 @@ module OmniauthRegistrationFormExtend
     include Decidim::JsonbAttributes
 
     def self.extra_params
-      [:custom_agreement, :number_and_street,
-       :address_complement,
-       :postal_code,
-       :city,
-       :country]
+      [:custom_agreement, :full_address]
     end
 
     attribute :custom_agreement, Virtus::Attribute::Boolean

--- a/lib/extends/omniauth_registration_form_extend.rb
+++ b/lib/extends/omniauth_registration_form_extend.rb
@@ -12,7 +12,11 @@ module OmniauthRegistrationFormExtend
     end
 
     attribute :custom_agreement, Virtus::Attribute::Boolean
-    attribute :full_address, String
+    attribute :number_and_street, String
+    attribute :address_complement, String
+    attribute :postal_code, String
+    attribute :city, String
+    attribute :country, String
 
     validates :email, 'valid_email_2/email': { mx: true }
     validates :name, presence: true
@@ -20,8 +24,10 @@ module OmniauthRegistrationFormExtend
     validates :uid, presence: true
     validates :custom_agreement, acceptance: true
 
-    validates :email, :full_address, presence: true, unless: -> (form) { form.email.blank? }
-    validates_length_of :full_address, maximum: 256, allow_blank: false, unless: -> (form) { form.email.blank? }
+    validates :email, :number_and_street,
+              :postal_code,
+              :city,
+              :country, presence: true, unless: -> (form) { form.email.blank? }
 
     validate :email, :email_is_unique, unless: -> (form) { form.email.blank? }
 
@@ -34,11 +40,14 @@ module OmniauthRegistrationFormExtend
       # Rails.logger.debug (((Time.zone.now - raw_data.dig(:extra, :raw_info, :birthdate).to_time) / 1.year.seconds).floor > manifest.dig(:minimum_age).to_i)
       # Rails.logger.debug "+++ ++++++++++++++++ +++"
 
-      if (((Time.zone.now - raw_data.dig(:extra, :raw_info, :birthdate).to_time) / 1.year.seconds).floor > manifest.dig(:minimum_age).to_i)
-        return true
+      if ((Time.zone.now - raw_data.dig(:extra, :raw_info, :birthdate).to_time) / 1.year.seconds).floor > manifest.dig(:minimum_age).to_i
+        true
       else
-        errors.add(:minimum_age, I18n.t("decidim.verifications.omniauth.errors.minimum_age", minimum_age: manifest.dig(:minimum_age), locale: I18n.locale))
-        return false
+        errors.add(:minimum_age,
+                   I18n.t("decidim.verifications.omniauth.errors.minimum_age",
+                          minimum_age: manifest.dig(:minimum_age),
+                          locale: I18n.locale))
+        false
       end
     end
 

--- a/lib/extends/update_account_extend.rb
+++ b/lib/extends/update_account_extend.rb
@@ -10,11 +10,15 @@ module UpdateAccountExtend
 
     def update_personal_data
       @user.email = @form.email
-      @user.full_address = @form.full_address
+      @user.address = @form.address
+      @user.full_address = computed_full_address
       @user.custom_agreement_at = DateTime.now if @form.custom_agreement
       @user.email_on_notification = @form.email_on_notification
     end
 
+    def computed_full_address
+      "#{@form.number_and_street}, #{@form.city} #{@form.postal_code}, #{@form.country}"
+    end
   end
 end
 


### PR DESCRIPTION
## What ? Why ? 

Add new fields related to user address in omniauth registration form. 

Fields are : 
- [x] Number and street (required)
- [x] Address complement 
- [x] Postal code (required)
- [x] City (required)
- [x] Country (required)

## New behaviour

When user sign up, the `full_address` field is computed using the new fields added in registration form. Furthermore, when user edits her account, the `full_address` is computed again using the new values. 

## Tasks : 
- [x] Add new fields in registration form
- [x] Add new fields in update account form
- [x] Keep current field `full_address`
- [x] Compute new `full_address` using new fields values
- [x] Disable `full_address` edition
- [x] Add `address_complement` to admin verifications metadata [OPTIONAL]

## Screenshots current changes
<img width="450" alt="Screenshot 2020-10-22 at 16 41 22" src="https://user-images.githubusercontent.com/26109239/96893346-e4b45d00-148a-11eb-8fee-5c704f3b3a5b.png">

<img width="450" alt="Screenshot 2020-10-22 at 17 21 49" src="https://user-images.githubusercontent.com/26109239/96893567-21805400-148b-11eb-916c-7ff738f899aa.png">

