### PR TITLE
Reformat full address user field

### DIFF
--- a/db/migrate/20201109101813_update_address_users_for_decidim_users.rb
+++ b/db/migrate/20201109101813_update_address_users_for_decidim_users.rb
@@ -1,0 +1,7 @@
+class UpdateAddressUsersForDecidimUsers < ActiveRecord::Migration[5.2]
+  def up
+    Decidim::User.where.not(full_address: nil, address: {}).find_each do |user|
+      user.update(full_address: user.computed_full_address(user.address))
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_22_120625) do
+ActiveRecord::Schema.define(version: 2020_11_09_101813) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"

--- a/lib/extends/create_omniauth_registration_extend.rb
+++ b/lib/extends/create_omniauth_registration_extend.rb
@@ -73,7 +73,7 @@ module CreateOmniauthRegistrationExtend
           @user.password_confirmation = generated_password
 
           @user.address = form.address
-          @user.full_address = computed_full_address
+          @user.full_address = @user.computed_full_address(@user.address)
           @user.custom_agreement_at = DateTime.now if form.custom_agreement
 
           # TODO: raise ActiveRecord::RecordInvalid because of quality setting on uploader, this line is a quick fix
@@ -86,12 +86,6 @@ module CreateOmniauthRegistrationExtend
 
       @user.tos_agreement = '1'
       @user.save!
-    end
-
-    private
-
-    def computed_full_address
-      "#{form.number_and_street}, #{form.city} #{form.postal_code}, #{form.country}"
     end
   end
 end

--- a/lib/extends/update_account_extend.rb
+++ b/lib/extends/update_account_extend.rb
@@ -11,13 +11,9 @@ module UpdateAccountExtend
     def update_personal_data
       @user.email = @form.email
       @user.address = @form.address
-      @user.full_address = computed_full_address
+      @user.full_address = @user.computed_full_address(@user.address)
       @user.custom_agreement_at = DateTime.now if @form.custom_agreement
       @user.email_on_notification = @form.email_on_notification
-    end
-
-    def computed_full_address
-      "#{@form.number_and_street}, #{@form.city} #{@form.postal_code}, #{@form.country}"
     end
   end
 end

--- a/lib/extends/user_model_extend.rb
+++ b/lib/extends/user_model_extend.rb
@@ -9,6 +9,10 @@ module UserModelExtend
     def email_required?
       false
     end
+
+    def computed_full_address(address)
+      "#{address["number_and_street"]}, #{address["postal_code"]} #{address["city"]}, #{address["country"]}"
+    end
   end
 end
 


### PR DESCRIPTION
## What ? Why ? 

Add migration to reformat all full_address field with the wanted format : 

1. form.number_and_street
1. form.postal_code
1. form.city
1. form.country

## Subtasks

- [x] Migration for updating all `full_address` fields if `address` field is already defined
- [x] Move duplicated `computed_full_address` definition to user model extend

## Screenshots

New `full_address` format 

<img width="400" alt="Screenshot 2020-11-09 at 13 39 21" src="https://user-images.githubusercontent.com/26109239/98543024-21a58f80-2292-11eb-99ca-82489af249bb.png">

