### PR TITLE
remove disabled destroy account extend

### DIFF
--- a/config/initializers/extends.rb
+++ b/config/initializers/extends.rb
@@ -10,6 +10,6 @@ if defined?(Decidim::Initiatives)
 end
 require "extends/organization_appearance_form_extend"
 require "extends/update_organization_appearance_extend"
-# require "extends/destroy_account_extend"
+require "extends/destroy_account_extend"
 require "extends/create_omniauth_registration_extend"
 require "extends/update_account_extend"

--- a/lib/extends/destroy_account_extend.rb
+++ b/lib/extends/destroy_account_extend.rb
@@ -5,12 +5,10 @@ module DestroyAccountExtend
   extend ActiveSupport::Concern
 
   included do
-
     def call
       return broadcast(:invalid) unless @form.valid?
 
       Decidim::User.transaction do
-
         manage_user_initiatives
         destroy_user_account!
         destroy_user_authorizations


### PR DESCRIPTION
#### What ? Why ? 

Admin receives notification when user destroy her account. 

#### Tasks : 
- [x] Remove comment for loading destroy account extend