### PR TITLE
Notify admins when user destroy account

### DIFF
--- a/lib/extends/destroy_account_extend.rb
+++ b/lib/extends/destroy_account_extend.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
-require "active_support/concern"
+
+require 'active_support/concern'
 
 module DestroyAccountExtend
   extend ActiveSupport::Concern
@@ -9,6 +10,7 @@ module DestroyAccountExtend
       return broadcast(:invalid) unless @form.valid?
 
       Decidim::User.transaction do
+        notify_admins
         manage_user_initiatives
         destroy_user_account!
         destroy_user_authorizations
@@ -20,6 +22,8 @@ module DestroyAccountExtend
       broadcast(:ok)
     end
 
+    private
+
     def manage_user_initiatives
       # Rails.logger.debug "+++++++++++++++++++++++++"
       # Rails.logger.debug "DestroyAccount.manage_user_initiatives"
@@ -30,22 +34,38 @@ module DestroyAccountExtend
       Decidim::Initiative.where(author: @user).each do |initiative|
         # Rails.logger.debug initiative.id
         # Rails.logger.debug initiative.state
-        if %w(created validating accepted).include?(initiative.state)
+        if %w[created validating accepted].include?(initiative.state)
           # Rails.logger.debug "will be discarded"
-          initiative.update_columns(state: "discarded")
+          initiative.update_columns(state: 'discarded')
         else
           # Rails.logger.debug "will be rejected"
-          initiative.update_columns(state: "rejected")
+          initiative.update_columns(state: 'rejected')
         end
         # Rails.logger.debug "--"
       end
+    end
 
+    def notify_admins
+      organization_admins.each do |admin|
+        Decidim::DestroyAccountMailer.notify(admin).deliver_later
+      end
+    end
+
+    # Returns array of administrators with email on notification enabled
+    def organization_admins
+      Decidim::User.where(
+        organization: @user.organization,
+        admin: true,
+        email_on_notification: true
+      ).where.not(id: @user.id)
     end
 
     def destroy_user_authorizations
-      Decidim::Verifications::Authorizations.new(organization: @user.organization, user: @user).query.destroy_all
+      Decidim::Verifications::Authorizations.new(
+        organization: @user.organization,
+        user: @user
+      ).query.destroy_all
     end
-
   end
 end
 


### PR DESCRIPTION
#### What ? Why ? 

When user destroys her account, administrators with `email_on_notification` enabled should receive an email. 

#### Task
- [x] Notify admins when an account is destroyed