### PR TITLE
Fix/archive filter not displayed

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -537,7 +537,9 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.0512)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_magick (4.10.1)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
@@ -915,4 +917,4 @@ RUBY VERSION
    ruby 2.6.5p114
 
 BUNDLED WITH
-   2.2.9
+   2.2.16

--- a/app/helpers/decidim/initiatives/application_helper.rb
+++ b/app/helpers/decidim/initiatives/application_helper.rb
@@ -18,7 +18,11 @@ module Decidim
                         TreePoint.new("accepted", t("decidim.initiatives.application_helper.filter_state_values.accepted")),
                         TreePoint.new("rejected", t("decidim.initiatives.application_helper.filter_state_values.rejected"))
                     ]
-                )
+                ),
+                TreeNode.new(
+                    TreePoint.new("archived", t("decidim.initiatives.application_helper.filter_state_values.archived")),
+                    archives_categories_value
+                ),
             ]
         )
       end
@@ -111,6 +115,14 @@ module Decidim
               end
           )
         end
+      end
+
+      def archives_categories_value
+        archive_categories.map { |archive_category| TreePoint.new(archive_category.name, archive_category.name) }
+      end
+
+      def archive_categories
+        @archive_categories ||= Decidim::InitiativesArchiveCategory.where(organization: current_organization)
       end
     end
   end

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -110,6 +110,9 @@ fr:
             email_subject: decidim.event.initiatives.admin.support_threshold_reached.email_subject
             notification_title: decidim.event.initiatives.admin.support_threshold_reached.notification_title
     initiatives:
+      application_helper:
+        filter_state_values:
+          archived: Archivée
       update:
         error: fr.decidim.initiatives.update.error
         success: fr.decidim.initiatives.update.success


### PR DESCRIPTION
#### What ? Why ? 

At the moment "Archive" checkbox in filters is not present. Issue is due to monkey patch in osp-app.

Add "Archive" filter checkbox to initiatives view.

#### 📷 Screenshot

Filter 
<img width="1379" alt="Screenshot 2021-06-07 at 12 23 37" src="https://user-images.githubusercontent.com/26109239/121001075-31834480-c78b-11eb-8d7f-2f6756e7e168.png">
