### PR TITLE
Initiative progress bar must be refreshed on asynchronous loading

### DIFF
--- a/app/assets/javascripts/decidim/initiatives/threshold.js
+++ b/app/assets/javascripts/decidim/initiatives/threshold.js
@@ -1,5 +1,10 @@
 document.addEventListener("DOMContentLoaded",function() {
+  updateThreshold();
+});
 
+
+// When page contains initiatives, update each progress bar for initiatives which have reached first threshold (100 000)
+function updateThreshold() {
   if (window.location.pathname.startsWith("/initiatives")) {
     var seuil_1_str = "100 000";
     var seuil_2_str = "500&nbsp000";
@@ -22,5 +27,4 @@ document.addEventListener("DOMContentLoaded",function() {
       }
     });
   }
-
-});
+}

--- a/app/views/decidim/initiatives/initiatives/index.js.erb
+++ b/app/views/decidim/initiatives/initiatives/index.js.erb
@@ -1,0 +1,17 @@
+var $initiatives = $('#initiatives');
+var $initiativesCount = $('#initiatives-count');
+var $orderFilterInput = $('.order_filter');
+
+$initiatives.html('<%= j(render partial: "decidim/initiatives/initiatives/initiatives") %>');
+$initiativesCount.html('<%= j(render partial: "decidim/initiatives/initiatives/count") %>');
+$orderFilterInput.val('<%= order %>');
+
+// Update initiative threshold when page is reloaded asynchronously
+// Function will be called every time initiatives are reloaded :
+// - Filtering
+// - Sorting initiatives
+// Define in : app/assets/javascripts/decidim/initiatives/threshold.js
+updateThreshold();
+
+var $dropdownMenu = $('.dropdown.menu', $initiatives);
+$dropdownMenu.foundation();


### PR DESCRIPTION
#### Description 

When initiative signature threshold is reached (100 000), progress bar must be reloaded to the next threshold (500 000). When DOM is loaded, each initiatives progress bar are updated if needed. 

At the moment, JS isn't triggered again when initiatives are reloaded asynchronously. This PR trigger progress bar update on every async loading (Filter or Sort of initiatives).

#### How to test

You can add a temporary `console.log("Javascript reloaded")` in file : `app/assets/javascripts/decidim/initiatives/threshold.js` after the line **8**.

1. Run application locally
2. In your browser : Open the Chrome Dev Tool
3. Go to homepage (`/`) : You should not see any console.log : `Javascript reloaded`
4. Go to initiatives index (`/initiatives`) : You should see a unique console.log : `Javascript reloaded`
5. Without reloading page: try async actions like (changing filters, changing sortition), You should see console.log : `Javascript reloaded` every time initiatives changes
6. Initiative show view keeps the same behaviour

If you want to test the update of progress bar : 
1. Define a signature threshold
2. Create test initiative with threshold reached
3. In `app/assets/javascripts/decidim/initiatives/threshold.js`, update variable `seuil_1_str` to newly defined threshold
4. See updated progress bar on each initiatives sync / async loading