### PR TITLE
Fix initiative exports dropdown

### DIFF
--- a/app/helpers/decidim/initiatives/admin/initiatives_helper.rb
+++ b/app/helpers/decidim/initiatives/admin/initiatives_helper.rb
@@ -4,6 +4,14 @@ module Decidim
   module Initiatives
     module Admin
       module InitiativesHelper
+        def export_dropdown_path(format, collection_ids)
+          path = export_initiatives_path(format: format)
+          return path if collection_ids.blank?
+
+          ids = collection_ids.join(",")
+          path.concat("?cid=#{ids}")
+        end
+
         def export_dropdown(collection_ids = nil)
           render partial: "decidim/initiatives/admin/exports/dropdown", locals: { collection_ids: collection_ids }
         end

--- a/app/views/decidim/initiatives/admin/exports/_dropdown.html.erb
+++ b/app/views/decidim/initiatives/admin/exports/_dropdown.html.erb
@@ -17,7 +17,7 @@
       <li class="exports--format--<%= format.downcase %> exports--initiatives">
         <%= link_to t("decidim.admin.exports.export_as", name: t("decidim.initiatives.admin.exports.initiatives"),
                       export_format: format.upcase),
-                    export_initiatives_path(format: format, collection_ids: collection_ids) %>
+                    export_dropdown_path(format, collection_ids) %>
       </li>
     <% end %>
   </ul>


### PR DESCRIPTION
#### Description 

Admin can't export initiatives because GET request is too long

#### Task : 

- Rename `collection_ids` param to `cid` and change format of the query params

